### PR TITLE
Make HTML's html-dfn.js work, part 4

### DIFF
--- a/lib/wattsi-client.js
+++ b/lib/wattsi-client.js
@@ -197,7 +197,8 @@ class WattsiClient {
     }
     
     lines(stdout) {
-        return stdout.trim().split("\n");
+        let trimmed = stdout.trim();
+        return trimmed ? trimmed.split("\n") : [];
     }
     
     filter(lines) {
@@ -248,17 +249,13 @@ class WattsiClient {
         }
     }
 
-    // Fetch html-dfn.js for the PR's head SHA, rewrite its xrefs.json fetch to be
-    // sibling-relative, and write it to dfnJsPath for the uploader to pick up.
     async fetchHtmlDfn() {
         const url = `https://raw.githubusercontent.com/whatwg/html/${ this.pr.head_sha }/html-dfn.js`;
         const response = await fetch(url);
         if (!response.ok) {
             throw new Error(`Failed to fetch ${ url }: ${ response.status } ${ response.statusText }`);
         }
-        let content = await response.text();
-        content = content.replace(/fetch\((["'])\/xrefs\.json\1\)/g, "fetch($1xrefs.json$1)");
-        await fs.promises.writeFile(this.dfnJsPath, content, "utf8");
+        await fs.promises.writeFile(this.dfnJsPath, await response.text(), "utf8");
     }
     
     cleanup() {


### PR DESCRIPTION
Some minor cleanup:

- If all that was changed was html-dfn.js, PR Preview would emit "Error: EISDIR: illegal operation on a directory, read" due to lines() returning a list of 1 rather than 0.
- Now that we use import() for xrefs.json in html-dfn.js, it always works as long as it is placed alongside it. This allows us to remove some code that now no-ops. We also remove a comment that states what the code does while there.