### PR TITLE
Update repository references from tobie to specinfra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ you **must** add a configuration file to the root of your repository.
 Nothing will happen until you do.
 
 Note that the following orgs have blanket install of pr-preview,
-which means that [adding a config file](https://tobie.github.io/pr-preview/config.html)
+which means that [adding a config file](https://specinfra.github.io/pr-preview/config.html)
 is all you need to be setup if your repository is hosted in one of them:
 
 * [github.com/w3c](https://github.com/w3c/)
@@ -57,7 +57,7 @@ is all you need to be setup if your repository is hosted in one of them:
 ## Configuration file
 
 _To test your own config file and turn it into a pull request,
-go to the [config page](https://tobie.github.io/pr-preview/config.html)._
+go to the [config page](https://specinfra.github.io/pr-preview/config.html)._
 
 You must configure PR Preview by adding a
 `.pr-preview.json` json file at the root of your repository

--- a/lib/models/branch.js
+++ b/lib/models/branch.js
@@ -102,7 +102,7 @@ class MergeBase extends mix(Branch).with(ImmutableCache, Fetchable) {
     get ignore_bikeshed_errors() {
         // Ignore errors in the base branch, to enable users to get results for
         // the PR without being blocked on resolving all errors in the base
-        // commit. E.g. see https://github.com/tobie/pr-preview/issues/177
+        // commit. E.g. see https://github.com/specinfra/pr-preview/issues/177
         return true;
     }
 }

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -45,7 +45,7 @@ module.exports.addDefault = function(config) {
             config.params = config.params || {};
         }
         if (!("md-warning" in config.params) && config.params["md-status"] !== "LS-PR") {
-            // See https://github.com/tobie/pr-preview/issues/55 for why LS-PR is special-cased.
+            // See https://github.com/specinfra/pr-preview/issues/55 for why LS-PR is special-cased.
             config.params["md-warning"] = "not ready";
         }
     } else if (type == "wattsi") {

--- a/lib/views/error.js
+++ b/lib/views/error.js
@@ -23,7 +23,7 @@ ${ this.summary(err, pr) }
 
     lead(err, pr) {
         let str = this.lastTried(new Date(), pr);
-        return `[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. ${ str }.`;
+        return `[PR Preview](https://github.com/specinfra/pr-preview#pr-preview) failed to build. ${ str }.`;
     }
     
     lastTried(date, pr) {
@@ -101,7 +101,7 @@ ${ fileIssue }
     }
     
     issueUrl(pr) {
-        var base = "https://github.com/tobie/pr-preview/issues/new";
+        var base = "https://github.com/specinfra/pr-preview/issues/new";
         return `${base}?title=Unidentified%20Error&body=See%20${pr.owner}/${pr.repo}%23${pr.number}.`;
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tobie/webidl-pr-preview.git"
+    "url": "git+https://github.com/specinfra/pr-preview.git"
   },
   "author": "Tobie Langel <tobie@codespeaks.com>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/tobie/webidl-pr-preview/issues"
+    "url": "https://github.com/specinfra/pr-preview/issues"
   },
   "engines": {
     "node": ">=20.0.0"
   },
-  "homepage": "https://github.com/tobie/webidl-pr-preview#readme",
+  "homepage": "https://github.com/specinfra/pr-preview#readme",
   "devDependencies": {
     "mocha": "^6.1.4",
     "supertest": "^7.1.4"


### PR DESCRIPTION
## Summary
This pull request updates all repository references throughout the codebase to reflect the migration from the `tobie` GitHub organization to the `specinfra` organization.

## Key Changes
- Updated `package.json` repository URL, bugs URL, and homepage to point to `specinfra/pr-preview` instead of `tobie/webidl-pr-preview`
- Updated README.md documentation links to reference the new `specinfra.github.io/pr-preview` domain
- Updated GitHub repository links in error messages and comments to use the new `specinfra/pr-preview` organization
- Updated GitHub Actions workflow to use `main` branch instead of `master` as the default branch

## Files Modified
- `package.json` - Repository metadata
- `README.md` - Documentation links
- `lib/views/error.js` - Error message links
- `lib/models/branch.js` - Comment reference
- `lib/models/config.js` - Comment reference
- `.github/workflows/test.yml` - CI/CD branch configuration

This change ensures all documentation, error messages, and configuration consistently point to the new organization home while maintaining the same functionality.

https://claude.ai/code/session_015nPK1nBuTeVJydm3618Lgr