### PR TITLE
fix: upgrade form-data to 4.0.6 (CVE-2025-7783)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -870,7 +870,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -1154,16 +1153,19 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/formidable": {
@@ -1408,7 +1410,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -1420,9 +1421,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3518,22 +3520,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/superagent/node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/superagent/node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "tv4": "1.3.0",
     "urlencode": "1.1.0",
     "webidl-grammar-post-processor": "^0.4.1"
+  },
+  "overrides": {
+    "form-data": "^4.0.4"
   }
 }


### PR DESCRIPTION
Upgrades `form-data` from 2.3.3 to 4.0.6 across the dependency tree, fixing CVE-2025-7783 (unsafe `Math.random` used to generate multipart boundaries).

This is an alternative to #193, which reported the vulnerability and proposed the same upgrade — credit to @anupamme for finding it. The difference is only in how the override is expressed, plus a rebase onto current `main`. #193 can be closed once this lands.

## The change

Three lines in `package.json`:

```json
"overrides": {
  "form-data": "^4.0.4"
}
```

#193 listed eleven override entries, but only `request` and `superagent` actually depend on `form-data` — the rest are ancestors, so those entries are redundant, and `"form-data": { "form-data": "4.0.6" }` had `form-data` overriding its own nested copy of itself. A single top-level override resolves the whole tree identically. A range rather than an exact pin means the next `form-data` patch release gets picked up without another manifest change.

This also yields a smaller lockfile diff, since npm hoists `hasown` to 2.0.4 at the top level instead of nesting a second copy under `form-data/node_modules/`.

## Why it matters here

The vulnerable code path is reachable, not just present in the tree: `lib/wattsi-client.js` posts multipart bodies to the Wattsi server through `request`'s `formData` option, which is exactly what generates the boundaries. Practical exploitability is low — the three form parts are streams fetched from GitHub, caniuse and MDN rather than attacker-controlled values — but the upgrade is worth making.

## Verification

`request@2.88.0` declares `form-data: ~2.3.2`, so this hands it a version two majors ahead, and nothing in the test suite covers that path. To check it directly, I captured the raw multipart body `request` produces on both the old and new trees, using the actual upstream paths from `lib/wattsi-client.js` (`/whatwg/html/<sha>/source`, `/Fyrd/caniuse/master/data.json`, `/w3c/mdn-spec-links/master/html.json`) with the random boundary normalised so the two runs are diffable.

form-data 2.3.3 and 4.0.6 produce **byte-for-byte identical** output, including the per-part headers:

```
Content-Disposition: form-data; name="source"; filename="source"
Content-Type: application/octet-stream

Content-Disposition: form-data; name="caniuse"; filename="data.json"
Content-Type: application/json

Content-Disposition: form-data; name="mdn"; filename="html.json"
Content-Type: application/json
```

Run twice — once with an `application/octet-stream` upstream and once with `text/plain; charset=utf-8`, matching what GitHub raw serves for the extensionless `source` file, since that exercises a different branch of form-data's content-type derivation. Identical both times. Both trees also resolve the same `mime-types@2.1.35`. Since the bytes on the wire are unchanged, the Wattsi server cannot distinguish the two versions.

Also confirmed: clean `npm ci` from an empty `node_modules`, `npm test` 84 passing, and `npm ls form-data` showing a single deduped 4.0.6 for both `request` and `superagent`.

**Not covered:** the happy path only. `fetchZip()` also destroys the request mid-upload via its `onerror` handler, and I did not exercise that abort path across the version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUcX1uxbgdfzgRg9CLyE1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUcX1uxbgdfzgRg9CLyE1d)_