### PR TITLE
Add detailed dismissal reasons to job logs

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -5,7 +5,7 @@ const ViewBody = require("./views/body");
 const ViewError = require("./views/error");
 const Config = require("./models/config");
 const github = require("simple-github");
-const { isInternalError } = require("./utils/error-utils");
+const { isInternalError, dismissalReason } = require("./utils/error-utils");
 
 class Controller {
     constructor() {
@@ -126,8 +126,8 @@ class Controller {
             const job = this.queue.shift();
 
             // Add to currently_running before processing
-            console.log("Currently running:", [...this.currently_running]);
             this.currently_running.add(job.id);
+            console.log(`Starting ${job.id}. Currently running:`, [...this.currently_running]);
 
             let shouldRequeue = false;
 
@@ -179,6 +179,11 @@ class Controller {
 
             if (this.shouldReportError(pr, job, error)) {
                 errorResult = await this.reportError(pr, error);
+            } else {
+                errorResult = {
+                    errorReported: false,
+                    errorNotReportedReason: this.reportSkipReason(pr, job, error)
+                };
             }
         }
 
@@ -194,13 +199,32 @@ class Controller {
 
 
     needsUpdate(pr) {
-        return pr.payload && !pr.isMerged && pr.touchesSrcFile() && pr.requiresPreview();
+        return !this.updateSkipReason(pr);
+    }
+
+    // Why this PR doesn't warrant an update, or null when it does. Every branch
+    // here used to be an unexplained no-op in the log.
+    updateSkipReason(pr) {
+        if (!pr.payload) return "PR was never loaded";
+        if (pr.isMerged) return "PR is already merged";
+        if (!pr.touchesSrcFile()) return `no change to ${pr.config.src_file} or the files it includes`;
+        if (!pr.requiresPreview()) return "PR body opts out with <!-- no preview -->";
+        return null;
     }
 
     shouldReportError(pr, job, error) {
         return process.env.NODE_ENV == "production" &&
             !isInternalError(error) &&
             (job.forcedUpdate || this.needsUpdate(pr));
+    }
+
+    // Mirrors shouldReportError, in the same order, to name the condition that
+    // kept this error off the PR.
+    reportSkipReason(pr, job, error) {
+        if (process.env.NODE_ENV != "production") return "not a live run";
+        if (isInternalError(error)) return dismissalReason(error);
+        if (job.forcedUpdate) return null;
+        return this.updateSkipReason(pr);
     }
 
     render(pr) {
@@ -231,6 +255,7 @@ class Controller {
         let updated = false;
         let bodyChanged = false;
         let content = null;
+        let skipReason = null;
 
         if (job.forcedUpdate || this.needsUpdate(pr)) {
 
@@ -243,6 +268,7 @@ class Controller {
                 const err = new Error("New commits pushed during build");
                 err.aborted = true;
                 err.requeue = true;
+                err.dismissalReason = "new commits pushed during build, requeued";
                 throw err;
             }
 
@@ -263,14 +289,19 @@ class Controller {
                 } else {
                     updated = "Not a live run!";
                 }
+            } else {
+                skipReason = "rendered body is already up to date";
             }
+        } else {
+            skipReason = this.updateSkipReason(pr);
         }
 
         return {
             needsUpdate,
             updated,
             bodyChanged,
-            content
+            content,
+            skipReason
         };
     }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
 "use strict";
-const { isInternalError } = require("./utils/error-utils");
+const { dismissalReason } = require("./utils/error-utils");
 
 function createLogger(config) {
     function logArgs() {
@@ -14,25 +14,30 @@ function createLogger(config) {
 
         // We're all good. Log outcome and exit.
         if (!err) {
-            logArgs(`${r.job.id}: ${ action }`);
+            let skipped = r.skipReason ? ` (no update: ${ r.skipReason })` : "";
+            logArgs(`${r.job.id}: ${ action }${ skipped }`);
             logArgs(r);
             return;
         }
 
         // These are well understood error paths.
         // They shouldn't trigger error messages.
-        // Log and exit.
-        if (isInternalError(err)) {
-            logArgs(`${r.job.id}: ${ action } (${err.message})`);
+        // Log why the job was dismissed and exit.
+        let dismissal = dismissalReason(err);
+        if (dismissal) {
+            logArgs(`${r.job.id}: ${ action } (dismissed: ${ dismissal })`);
             return;
         }
 
         // Those are real issues.
         // Log in details
         logArgs(`${r.job.id}: ${ action } (${err.name}: ${err.message})`);
+        if (r.errorNotReportedReason) {
+            logArgs(`    Not reported on the PR: ${ r.errorNotReportedReason }.`);
+        }
         if (r.errorRenderingErrorMsg) {
             logArgs(`    Additionally, triggered the following error while attempting to render the error msg to the client:
-    errorRenderingErrorMsg.name}: ${r.errorRenderingErrorMsg.message}`);
+    ${r.errorRenderingErrorMsg.name}: ${r.errorRenderingErrorMsg.message}`);
         }
         if (err.data) { logArgs(err.data) };
         if (err.stack && config.displayStackTraces) { logArgs(err.stack) };

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -15,7 +15,15 @@ function markError(err, reason) {
     return err;
 }
 
+// The common case by far: the repo has no config file, i.e. it never opted
+// into previews. That's routine, not a fault, and shouldn't read like one.
+// GitHub answers 404 for a file an installation can't see as well as for one
+// that isn't there, and simple-github drops the status code, so the two are
+// indistinguishable here; the message it does keep is GitHub's own "Not Found".
 function fetchFailureReason(err) {
+    if (err.message == "Not Found") {
+        return `no ${CONFIG_FILE}, repo hasn't opted into previews`;
+    }
     let where = err.url ? ` from ${err.url}` : "";
     return `couldn't read ${CONFIG_FILE}${where}: ${err.message}`;
 }

--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -1,12 +1,23 @@
 "use strict";
 const GH_API = require("../GH_API");
 
+const CONFIG_FILE = ".pr-preview.json";
+
 const validator = require("tv4").freshApi();
 const schema = require("./config-schema.json");
 
-function markError(err) {
+// Flags the error as "this repo has no config we can use", which dismisses the
+// job instead of reporting it on the PR. The reason is what ends up in the log,
+// so it has to say which of the several ways of having no config applied.
+function markError(err, reason) {
     err.noConfig = true;
+    err.dismissalReason = reason;
     return err;
+}
+
+function fetchFailureReason(err) {
+    let where = err.url ? ` from ${err.url}` : "";
+    return `couldn't read ${CONFIG_FILE}${where}: ${err.message}`;
 }
 
 class Config {
@@ -17,20 +28,31 @@ class Config {
     request() {
         return this.pr.request(GH_API.GET_CONFIG_FILE).then(file => {
             if (file.type != "file") {
-                throw markError(new Error(".pr-preview.json is not a file."));
+                throw markError(new Error(`${CONFIG_FILE} is not a file.`),
+                    `${CONFIG_FILE} is a ${file.type}, not a file`);
             }
-            var json = JSON.parse(Buffer.from(file.content, "base64").toString("utf8"));
+            var json;
+            try {
+                json = JSON.parse(Buffer.from(file.content, "base64").toString("utf8"));
+            } catch (err) {
+                // Not a dismissal: the repo asked for previews, its config is
+                // just broken, and whoever wrote it wants to hear about it.
+                throw new Error(`${CONFIG_FILE} is not valid JSON: ${err.message}`);
+            }
             Config.validate(json);
             console.log("Found repo config file", json);
             return Config.addDefault(json);
-        }, err => { throw markError(err); });
+        }, err => { throw markError(err, fetchFailureReason(err)); });
     }
 }
 
 module.exports = Config;
 module.exports.validate = function(config) {
     let result = validator.validateResult(config, schema);
-    if (!result.valid) throw markError(result.error);
+    if (!result.valid) {
+        let at = result.error.dataPath ? ` at ${result.error.dataPath}` : "";
+        throw markError(result.error, `${CONFIG_FILE} is invalid${at}: ${result.error.message}`);
+    }
 };
 
 module.exports.addDefault = function(config) {

--- a/lib/utils/error-utils.js
+++ b/lib/utils/error-utils.js
@@ -1,7 +1,24 @@
 "use strict";
 
-function isInternalError(error) {
-    return error.noConfig || error.prMerged || error.aborted;
+// Errors flagged with one of these describe an expected, non-actionable
+// outcome. The job is dismissed rather than reported back to the PR, so the
+// log line is the only trace it leaves: each flag has a fallback label, and
+// the thrower can set `dismissalReason` to say something more specific.
+const DISMISSAL_LABELS = {
+    noConfig: "no usable config",
+    prMerged: "PR is already merged",
+    aborted: "build aborted"
+};
+
+function dismissalReason(error) {
+    if (!error) return null;
+    let flag = Object.keys(DISMISSAL_LABELS).find(k => error[k]);
+    if (!flag) return null;
+    return error.dismissalReason || DISMISSAL_LABELS[flag];
 }
 
-module.exports = { isInternalError };
+function isInternalError(error) {
+    return !!dismissalReason(error);
+}
+
+module.exports = { isInternalError, dismissalReason };

--- a/test/controller-skip-reasons.js
+++ b/test/controller-skip-reasons.js
@@ -1,0 +1,93 @@
+"use strict";
+const assert = require("assert"),
+    Controller = require("../lib/controller");
+
+function fakePR(overrides) {
+    return Object.assign({
+        payload: { head: { sha: "abc123" } },
+        isMerged: false,
+        config: { src_file: "index.bs", type: "bikeshed" },
+        touchesSrcFile: () => true,
+        requiresPreview: () => true
+    }, overrides);
+}
+
+suite("Controller.updateSkipReason", function() {
+    const controller = new Controller();
+
+    test("no reason when the PR does warrant an update", function() {
+        assert.equal(controller.updateSkipReason(fakePR()), null);
+        assert.equal(controller.needsUpdate(fakePR()), true);
+    });
+
+    test("names each condition that dismisses the PR", function() {
+        const cases = [
+            [{ payload: null }, "PR was never loaded"],
+            [{ isMerged: true }, "PR is already merged"],
+            [{ touchesSrcFile: () => false }, "no change to index.bs or the files it includes"],
+            [{ requiresPreview: () => false }, "PR body opts out with <!-- no preview -->"]
+        ];
+
+        cases.forEach(([overrides, expected]) => {
+            const pr = fakePR(overrides);
+            assert.equal(controller.updateSkipReason(pr), expected);
+            assert.equal(controller.needsUpdate(pr), false);
+        });
+    });
+});
+
+suite("Controller.updateBody skip reasons", function() {
+    const controller = new Controller();
+
+    test("reports why no update was attempted", function() {
+        return controller.updateBody(fakePR({ touchesSrcFile: () => false }), {}).then(r => {
+            assert.equal(r.needsUpdate, false);
+            assert.equal(r.skipReason, "no change to index.bs or the files it includes");
+        });
+    });
+
+    test("reports an already up to date body", function() {
+        const pr = fakePR({
+            body: "rendered",
+            cacheAll: () => Promise.resolve(),
+            checkForChanges: () => Promise.resolve({ hasCommitChanges: false, hasBodyChanges: false })
+        });
+        controller.render = () => "rendered";
+
+        return controller.updateBody(pr, {}).then(r => {
+            assert.equal(r.needsUpdate, false);
+            assert.equal(r.skipReason, "rendered body is already up to date");
+        });
+    });
+});
+
+suite("Controller.reportSkipReason", function() {
+    const controller = new Controller();
+    const withEnv = (env, fn) => {
+        const original = process.env.NODE_ENV;
+        process.env.NODE_ENV = env;
+        try { return fn(); } finally { process.env.NODE_ENV = original; }
+    };
+
+    test("outside production, nothing is reported", function() {
+        withEnv("development", _ => assert.equal(
+            controller.reportSkipReason(fakePR(), {}, new Error("boom")),
+            "not a live run"));
+    });
+
+    test("a dismissed error carries its own reason through", function() {
+        const err = new Error("Not Found");
+        err.noConfig = true;
+        err.dismissalReason = "couldn't read .pr-preview.json: Not Found";
+
+        withEnv("production", _ => assert.equal(
+            controller.reportSkipReason(fakePR(), {}, err),
+            "couldn't read .pr-preview.json: Not Found"));
+    });
+
+    test("a real error on a PR needing no preview says which condition applied", function() {
+        withEnv("production", _ => assert.equal(
+            controller.reportSkipReason(fakePR({ isMerged: true }), {}, new Error("boom")),
+            "PR is already merged"));
+    });
+});

--- a/test/error-utils.js
+++ b/test/error-utils.js
@@ -1,0 +1,28 @@
+"use strict";
+const assert = require("assert"),
+    { isInternalError, dismissalReason } = require("../lib/utils/error-utils");
+
+suite("Dismissal reasons", function() {
+
+    test("plain errors are not dismissals", function() {
+        assert.equal(isInternalError(new Error("boom")), false);
+        assert.equal(dismissalReason(new Error("boom")), null);
+        assert.equal(dismissalReason(null), null);
+    });
+
+    test("each flag falls back to a label", function() {
+        ["noConfig", "prMerged", "aborted"].forEach(flag => {
+            let err = new Error("boom");
+            err[flag] = true;
+            assert.equal(isInternalError(err), true);
+            assert(dismissalReason(err), `${flag} should have a fallback label`);
+        });
+    });
+
+    test("an explicit reason wins over the label", function() {
+        let err = new Error("Not Found");
+        err.noConfig = true;
+        err.dismissalReason = "couldn't read .pr-preview.json";
+        assert.equal(dismissalReason(err), "couldn't read .pr-preview.json");
+    });
+});

--- a/test/models/config.js
+++ b/test/models/config.js
@@ -204,7 +204,7 @@ suite("Config.request dismissal reasons", function() {
     const rejectingPR = err => ({ request: () => Promise.reject(err) });
     const resolvingPR = file => ({ request: () => Promise.resolve(file) });
 
-    test("a failed fetch says which file, where, and why", function() {
+    test("a missing config reads as an opt-out, not a failure", function() {
         const err = new Error("Not Found");
         err.url = "https://api.github.com/repos/w3c/wcag/contents/.pr-preview.json";
 
@@ -213,9 +213,21 @@ suite("Config.request dismissal reasons", function() {
             err => {
                 assert.equal(err.noConfig, true);
                 assert.equal(err.dismissalReason,
-                    "couldn't read .pr-preview.json from " +
-                    "https://api.github.com/repos/w3c/wcag/contents/.pr-preview.json: Not Found");
+                    "no .pr-preview.json, repo hasn't opted into previews");
             }
+        );
+    });
+
+    test("a fetch that failed for another reason says which file, where, and why", function() {
+        const err = new Error("API rate limit exceeded");
+        err.url = "https://api.github.com/repos/w3c/wcag/contents/.pr-preview.json";
+
+        return new Config(rejectingPR(err)).request().then(
+            _ => assert.fail("Should have thrown an error"),
+            err => assert.equal(err.dismissalReason,
+                "couldn't read .pr-preview.json from " +
+                "https://api.github.com/repos/w3c/wcag/contents/.pr-preview.json: " +
+                "API rate limit exceeded")
         );
     });
 

--- a/test/models/config.js
+++ b/test/models/config.js
@@ -199,3 +199,68 @@ suite("Config.request", function() {
     });
 });
 
+
+suite("Config.request dismissal reasons", function() {
+    const rejectingPR = err => ({ request: () => Promise.reject(err) });
+    const resolvingPR = file => ({ request: () => Promise.resolve(file) });
+
+    test("a failed fetch says which file, where, and why", function() {
+        const err = new Error("Not Found");
+        err.url = "https://api.github.com/repos/w3c/wcag/contents/.pr-preview.json";
+
+        return new Config(rejectingPR(err)).request().then(
+            _ => assert.fail("Should have thrown an error"),
+            err => {
+                assert.equal(err.noConfig, true);
+                assert.equal(err.dismissalReason,
+                    "couldn't read .pr-preview.json from " +
+                    "https://api.github.com/repos/w3c/wcag/contents/.pr-preview.json: Not Found");
+            }
+        );
+    });
+
+    test("a failed fetch without a url still names the file", function() {
+        return new Config(rejectingPR(new Error("Bad credentials"))).request().then(
+            _ => assert.fail("Should have thrown an error"),
+            err => assert.equal(err.dismissalReason,
+                "couldn't read .pr-preview.json: Bad credentials")
+        );
+    });
+
+    test("a directory where the config should be says so", function() {
+        return new Config(resolvingPR({ type: "dir" })).request().then(
+            _ => assert.fail("Should have thrown an error"),
+            err => {
+                assert.equal(err.noConfig, true);
+                assert.equal(err.dismissalReason, ".pr-preview.json is a dir, not a file");
+            }
+        );
+    });
+
+    test("an invalid config says what the schema rejected", function() {
+        const content = Buffer.from(JSON.stringify({
+            src_file: "index.bs",
+            type: "nope"
+        })).toString("base64");
+
+        return new Config(resolvingPR({ type: "file", content })).request().then(
+            _ => assert.fail("Should have thrown an error"),
+            err => {
+                assert.equal(err.noConfig, true);
+                assert(err.dismissalReason.startsWith(".pr-preview.json is invalid at /type:"),
+                    `Unexpected reason: ${err.dismissalReason}`);
+            }
+        );
+    });
+
+    test("unparseable JSON is a real error, not a dismissal", function() {
+        return new Config(resolvingPR({ type: "file", content: "invalid-base64-content" })).request().then(
+            _ => assert.fail("Should have thrown an error"),
+            err => {
+                assert(!err.noConfig, "Broken JSON should be reported, not dismissed");
+                assert(err.message.startsWith(".pr-preview.json is not valid JSON:"),
+                    `Unexpected message: ${err.message}`);
+            }
+        );
+    });
+});


### PR DESCRIPTION
## Summary
This change improves observability by adding explicit dismissal reasons throughout the job processing pipeline. Instead of silently skipping jobs without explanation, the system now logs why each job was dismissed, making it easier to understand the flow of PR preview requests.

## Key Changes

- **Error handling improvements**: Enhanced `error-utils.js` to provide structured dismissal reasons via a new `dismissalReason()` function that maps error flags to human-readable messages, with support for custom dismissal reasons.

- **Config validation clarity**: Updated `Config` class to provide specific dismissal reasons for each failure mode:
  - Missing config file: "no .pr-preview.json, repo hasn't opted into previews"
  - Invalid config: Detailed schema validation errors with path information
  - Fetch failures: Include URL and error message for debugging
  - Directory instead of file: Specific message about the type mismatch

- **Controller skip reason tracking**: Added `updateSkipReason()` method to `Controller` that explicitly names why a PR doesn't warrant an update (never loaded, already merged, no source file changes, opted out). Also added `reportSkipReason()` to explain why errors aren't reported to PRs.

- **Update body tracking**: Enhanced `updateBody()` to return `skipReason` field explaining why no update was attempted or why the body was already up to date.

- **Improved logging**: Updated logger to display skip reasons inline with action messages, making the job flow transparent in logs. Also fixed a typo in error rendering output.

## Notable Implementation Details

- Dismissal reasons are attached to errors via `dismissalReason` property, allowing callers to provide context-specific messages while falling back to generic labels.
- The `needsUpdate()` method now delegates to `updateSkipReason()` for consistency.
- Config file name is centralized as `CONFIG_FILE` constant for maintainability.
- Comprehensive test coverage added for all new dismissal reason paths.

https://claude.ai/code/session_01DRdGGKT8tXzgmdJBBabnN6