### PR TITLE
Fix WattsiClient.cleanup to use correct dirPath property

### DIFF
--- a/lib/wattsi-client.js
+++ b/lib/wattsi-client.js
@@ -260,7 +260,7 @@ class WattsiClient {
     
     cleanup() {
         return new Promise((resolve, reject) => {
-            exec(`rm -rf ${this.dir}`, (err, stdout, stderr) => {
+            exec(`rm -rf ${ this.dirPath }`, (err, stdout, stderr) => {
                 if (err) {
                     reject(err);
                 } else {

--- a/test/wattsi-client.js
+++ b/test/wattsi-client.js
@@ -61,3 +61,49 @@ suite('WattsiClient.findFilesOnlyIn', function() {
         assert.deepEqual(w.findFilesOnlyIn("./foo/bar/baz", lines), ["bar.html"]);
     });
 });
+
+suite('WattsiClient.cleanup', function() {
+    var childProcess = require('child_process'),
+        originalExec = childProcess.exec,
+        modulePath = require.resolve('../lib/wattsi-client'),
+        commands;
+
+    // wattsi-client binds child_process.exec at require time, so stub first and
+    // then load a fresh copy of the module that picks up the stub.
+    setup(function() {
+        commands = [];
+        childProcess.exec = function(cmd, callback) {
+            commands.push(cmd);
+            process.nextTick(function() { callback(null, "", ""); });
+        };
+        delete require.cache[modulePath];
+    });
+
+    teardown(function() {
+        childProcess.exec = originalExec;
+        delete require.cache[modulePath];
+    });
+
+    test('removes the per-PR directory (dirPath), not an undefined property', function() {
+        var StubbedWattsi = require('../lib/wattsi-client');
+        var w = new StubbedWattsi({ number: 1234 });
+        return w.cleanup().then(function() {
+            assert.deepEqual(commands, ["rm -rf " + w.dirPath]);
+            assert.ok(/\/pr-preview\/whatwg\/html\/1234$/.test(w.dirPath));
+            assert.ok(!/undefined/.test(commands[0]));
+        });
+    });
+
+    test('rejects when the command fails', function() {
+        childProcess.exec = function(cmd, callback) {
+            process.nextTick(function() { callback(new Error("rm failed")); });
+        };
+        var StubbedWattsi = require('../lib/wattsi-client');
+        var w = new StubbedWattsi({ number: 1234 });
+        return w.cleanup().then(function() {
+            assert.fail("expected cleanup to reject");
+        }, function(err) {
+            assert.equal(err.message, "rm failed");
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Fixed a bug in the `WattsiClient.cleanup()` method where it was referencing an undefined `this.dir` property instead of the correct `this.dirPath` property.

## Changes
- **lib/wattsi-client.js**: Updated the `cleanup()` method to use `this.dirPath` instead of `this.dir` in the rm command, preventing "undefined" from being passed to the shell command
- **test/wattsi-client.js**: Added comprehensive test suite for `WattsiClient.cleanup()` with:
  - Test to verify the correct directory path is used and "undefined" does not appear in the command
  - Test to verify proper error handling when the rm command fails
  - Proper setup/teardown to stub `child_process.exec` at module load time

## Implementation Details
The tests stub `child_process.exec` before requiring the module to ensure the WattsiClient picks up the stubbed version at require time. The cleanup method now correctly removes the per-PR directory using the `dirPath` property which follows the pattern `/pr-preview/whatwg/html/{pr-number}`.

https://claude.ai/code/session_01U3NVntRErJaxFWRMrQXNnx