### PR TITLE
Remove timestamp from pretty-printed logs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -205,7 +205,7 @@ Used when the PR owner is `whatwg`. Set `ALLOW_MULTIPLE_AWS_BUCKETS=no` to skip 
 - `PORT` — must be `8080` on Clever Cloud (the code defaults to `5000`)
 - `ALLOW_MULTIPLE_AWS_BUCKETS` — set to `no` to force use of the default bucket only and ignore `WHATWG_*` credentials
 - `STARTUP_QUEUE` — JSON array of PRs to process on startup
-- `LOG_FORMAT` — `pretty` (the default) for readable output, one line per event with error detail indented beneath it; `json` for newline-delimited JSON, one record per line, when a log collector is reading the output
+- `LOG_FORMAT` — `pretty` (the default) for readable output, one line per event with error detail indented beneath it and no timestamp of its own, since the Clever Cloud log stream already stamps every line; `json` for newline-delimited JSON, one record per line with its own `time`, when a log collector is reading the output
 - `LOG_LEVEL` — the least severe [pino level](https://getpino.io/#/docs/api?id=level-string) to log; defaults to `info`. `debug` adds the build's chatter: fetches, cache hits, file reads, the config as read, and the Wattsi client's directory listings
 
 ### Clever Cloud platform variables

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -137,13 +137,15 @@ dismissed or a request refused, `error` is a real failure. `LOG_LEVEL`
 (default `info`) sets the threshold, so the chatter is off unless asked
 for.
 
-By default the log is pretty-printed: each record is a timestamp, the
-level, `(pr-preview)`, then `<pr> (<action>): <message>` for a job, with
-error detail indented beneath. Fields the line already conveys aren't
-repeated under it. `LOG_FORMAT=json` writes newline-delimited JSON
-instead, one record per line with every field, for a log collector. The
-examples below are the pretty-printed form with the timestamp, level and
-name left out.
+By default the log is pretty-printed: each record is the level,
+`(pr-preview)`, then `<pr> (<action>): <message>` for a job, with error
+detail indented beneath. Fields the line already conveys aren't repeated
+under it, and there is no timestamp: the output is either watched live in
+a terminal or read through a log stream that stamps each line itself, as
+Clever Cloud's does. `LOG_FORMAT=json` writes newline-delimited JSON
+instead, one record per line with every field (`time` included), for a
+log collector. The examples below are the pretty-printed form with the
+level and name left out.
 
 ## The cases
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,7 +13,9 @@ const prUrl = require("./utils/pr-url");
 // Two formats write the same records:
 // - pretty, the default: one line per record, "<pr> (<action>): <msg>" for
 //   a job, with error detail indented beneath. Fields the line already
-//   conveys are left out (PRETTY_HIDDEN).
+//   conveys are left out (PRETTY_HIDDEN), and so is the time: the line is
+//   read live in a terminal, or in a log stream that stamps each line
+//   itself (Clever Cloud does), where a second timestamp is just noise.
 // - json, with LOG_FORMAT=json: newline-delimited JSON with every field,
 //   for a log collector.
 //
@@ -24,9 +26,10 @@ const prUrl = require("./utils/pr-url");
 
 const NAME = "pr-preview";
 
-// Fields the pretty line already conveys, so they aren't repeated under it.
+// Fields the pretty line already conveys, so they aren't repeated under it,
+// plus the time (see above).
 const PRETTY_HIDDEN = [
-    "pid", "hostname", "module", "pr", "action", "status", "reason", "bodyChanged",
+    "time", "pid", "hostname", "module", "pr", "action", "status", "reason", "bodyChanged",
     "running", "event", "method", "url", "key", "path", "config", "includes"
 ];
 
@@ -88,7 +91,6 @@ function createLogger(config) {
         destination: config.destination || 1,
         sync: true,
         colorize: config.colorize,
-        translateTime: "SYS:standard",
         ignore: PRETTY_HIDDEN.join(","),
         messageFormat,
         // Printed in this order, after the line they belong to.

--- a/test/logger.js
+++ b/test/logger.js
@@ -154,7 +154,8 @@ suite("Logger", function() {
 
     suite("pretty printing (the default)", function() {
         const pretty = config => memoryLogger(Object.assign({ logFormat: "pretty" }, config));
-        const LINE = /^\[\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d{3} [+-]\d{4}\] (DEBUG|INFO|WARN|ERROR) \(pr-preview\): (.*)$/;
+        // No timestamp: the terminal is live and a log stream stamps lines itself.
+        const LINE = /^(DEBUG|INFO|WARN|ERROR) \(pr-preview\): (.*)$/;
         const body = line => {
             const match = LINE.exec(line);
             assert(match, line);


### PR DESCRIPTION
## Summary
Removed automatic timestamp generation from pretty-printed log output, since timestamps are redundant when logs are either viewed live in a terminal or processed through a log stream that already stamps each line (as Clever Cloud does).

## Key Changes
- **lib/logger.js**: Removed `translateTime: "SYS:standard"` from the pino logger configuration and added `"time"` to the `PRETTY_HIDDEN` fields list to exclude timestamps from pretty-printed output
- **docs/error-handling.md**: Updated documentation to clarify that pretty-printed logs no longer include timestamps, explaining that they're unnecessary for live terminal viewing or log streams that provide their own timestamps
- **DEPLOYMENT.md**: Updated `LOG_FORMAT` environment variable documentation to note that pretty format has no timestamp of its own since Clever Cloud's log stream already stamps every line
- **test/logger.js**: Updated the pretty log line regex pattern to remove the timestamp component, reflecting the new format

## Implementation Details
The timestamp is still included in JSON format logs (via the `time` field) for log collectors that need it, maintaining full information in structured logging while keeping pretty-printed output clean and focused on the actual message content.

https://claude.ai/code/session_011dx5YEMfMCFjwS9uFEDYbi