### PR TITLE
Remove logger name field from all records

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -113,8 +113,8 @@ controller copies into `error.data.errors` so it shows up too.
 ### What the log sees
 
 The logger lives in `lib/logger.js` and is [pino](https://getpino.io).
-Every record is named `pr-preview` and says what it is about in fields;
-the message is the readable sentence. `index.js` hands the logger to the
+Every record says what it is about in fields; the message is the
+readable sentence. `index.js` hands the logger to the
 controller and the Express app; modules that log on their own (the S3
 cache, the fetch and file mixins, the spec-diff model, the include
 scanner, the config model, the Wattsi client) use it directly, bound to a
@@ -137,15 +137,15 @@ dismissed or a request refused, `error` is a real failure. `LOG_LEVEL`
 (default `info`) sets the threshold, so the chatter is off unless asked
 for.
 
-By default the log is pretty-printed: each record is the level,
-`(pr-preview)`, then `<pr> (<action>): <message>` for a job, with error
-detail indented beneath. Fields the line already conveys aren't repeated
+By default the log is pretty-printed: each record is the level, then
+`<pr> (<action>): <message>` for a job, with error detail indented
+beneath. Fields the line already conveys aren't repeated
 under it, and there is no timestamp: the output is either watched live in
 a terminal or read through a log stream that stamps each line itself, as
 Clever Cloud's does. `LOG_FORMAT=json` writes newline-delimited JSON
 instead, one record per line with every field (`time` included), for a
 log collector. The examples below are the pretty-printed form with the
-level and name left out.
+level left out.
 
 ## The cases
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,8 +4,7 @@ const pinoPretty = require("pino-pretty");
 const { dismissalReason } = require("./utils/error-utils");
 const prUrl = require("./utils/pr-url");
 
-// Logging is pino. Every record is named pr-preview and says what it is
-// about in fields: a job's `pr` and `action` (bound on a child logger from
+// Logging is pino. Every record says what it is about in fields: a job's `pr` and `action` (bound on a child logger from
 // jobLogger()), its `status` and `reason`, an `err` with the error's data
 // and, when DISPLAY_STACK_TRACES=yes, its stack. The message is the
 // readable sentence. Modules that log on their own bind a `module`.
@@ -23,8 +22,6 @@ const prUrl = require("./utils/pr-url");
 // info is what happened to a job, warn is a job dismissed or a request
 // refused, error is a real failure. LOG_LEVEL (default info) sets the
 // threshold.
-
-const NAME = "pr-preview";
 
 // Fields the pretty line already conveys, so they aren't repeated under it,
 // plus the time (see above).
@@ -80,7 +77,6 @@ function createLogger(config) {
     config = config || {};
     const serializeError = errorSerializer(config);
     const options = {
-        name: NAME,
         level: config.logLevel || "info",
         serializers: { err: serializeError, reportingError: serializeError }
     };

--- a/test/logger.js
+++ b/test/logger.js
@@ -20,14 +20,6 @@ function fields(record) {
 
 suite("Logger", function() {
 
-    test("every record is named pr-preview", function() {
-        const log = memoryLogger();
-        log.info("hello");
-        jobLogger(log, JOB).info("hello");
-        log.child({ module: "s3" }).info("hello");
-        assert.deepEqual(log.records().map(r => r.name), ["pr-preview", "pr-preview", "pr-preview"]);
-    });
-
     test("a job logger binds the PR and the action", function() {
         const log = memoryLogger();
         jobLogger(log, JOB).info("hello");
@@ -51,10 +43,10 @@ suite("Logger", function() {
         logStatus(log, "warn", "ignored", undefined, { event: "ping" });
         const [skipped, ignored] = log.records().map(fields);
         assert.deepEqual(skipped, {
-            level: 30, name: "pr-preview", pr: JOB.url, action: "synchronize",
+            level: 30, pr: JOB.url, action: "synchronize",
             status: "skipped", reason: "already queued", msg: "skipped (already queued)"
         });
-        assert.deepEqual(ignored, { level: 40, name: "pr-preview", status: "ignored", event: "ping", msg: "ignored" });
+        assert.deepEqual(ignored, { level: 40, status: "ignored", event: "ping", msg: "ignored" });
     });
 
     suite("logResult", function() {
@@ -154,8 +146,9 @@ suite("Logger", function() {
 
     suite("pretty printing (the default)", function() {
         const pretty = config => memoryLogger(Object.assign({ logFormat: "pretty" }, config));
-        // No timestamp: the terminal is live and a log stream stamps lines itself.
-        const LINE = /^(DEBUG|INFO|WARN|ERROR) \(pr-preview\): (.*)$/;
+        // No timestamp (the terminal is live and a log stream stamps lines
+        // itself) and no name: the process is the whole app.
+        const LINE = /^(DEBUG|INFO|WARN|ERROR): (.*)$/;
         const body = line => {
             const match = LINE.exec(line);
             assert(match, line);


### PR DESCRIPTION
## Summary
Removes the hardcoded `pr-preview` name field from all logger records, simplifying the logging output since the process itself is the whole app and doesn't need to identify itself in every log line.

## Changes
- Removed the `NAME = "pr-preview"` constant and stopped setting the `name` option when creating the pino logger
- Updated test assertions to no longer expect the `name` field in log records
- Updated the pretty-print regex pattern to remove `(pr-preview)` from the expected log line format
- Updated documentation to reflect that records no longer include a name field, as the process is the whole application

## Details
The logger previously added a `name: "pr-preview"` field to every record, which was redundant since this application is the entire process. By removing this field, log output becomes cleaner and more concise, especially in pretty-printed format where the level and PR/action information are already sufficient context.

https://claude.ai/code/session_01ESNyrfgCbty7Vui7uXRuKr