### PR TITLE
add optional ALLOWED_ORGS config to restrict organizations allowed to use a self-hosted instance of the service

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -204,6 +204,7 @@ Used when the PR owner is `whatwg`. Set `ALLOW_MULTIPLE_AWS_BUCKETS=no` to skip 
 - `NODE_ENV` — set to `production` for live operation (gates webhook signature verification and PR comment writes)
 - `PORT` — must be `8080` on Clever Cloud (the code defaults to `5000`)
 - `ALLOW_MULTIPLE_AWS_BUCKETS` — set to `no` to force use of the default bucket only and ignore `WHATWG_*` credentials
+- `ALLOWED_ORGS` — comma or whitespace separated list of GitHub logins the app runs for (e.g. `specinfra,whatwg`); PRs and config requests for repositories owned by anybody else are ignored. Unset means no restriction. Matched case-insensitively, and enforced by the app, not by GitHub — see the README
 - `STARTUP_QUEUE` — JSON array of PRs to process on startup
 - `LOG_FORMAT` — `pretty` (the default) for readable output, one line per event with error detail indented beneath it and no timestamp of its own, since the Clever Cloud log stream already stamps every line; `json` for newline-delimited JSON, one record per line with its own `time`, when a log collector is reading the output
 - `LOG_LEVEL` — the least severe [pino level](https://getpino.io/#/docs/api?id=level-string) to log; defaults to `info`. `debug` adds the build's chatter: fetches, cache hits, file reads, the config as read, and the Wattsi client's directory listings

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ Currently, the only supported ones are "emu-algify" and "webidl-grammar".
 
 Used to pass an options object to the post-processor.
 
+## Restricting the app to specific organizations
+
+If you self-host PR Preview,
+you can restrict it to a set of GitHub organizations (or user accounts)
+by setting the `ALLOWED_ORGS` environment variable
+to a comma separated list of logins:
+
+```
+ALLOWED_ORGS=w3c,whatwg
+```
+
+Pull requests targeting repositories owned by anybody else are then ignored,
+as are config validation requests for those repositories.
+Logins are matched case-insensitively.
+When `ALLOWED_ORGS` is empty or unset,
+the app runs for every installation.
+
+Note this is enforced by the app itself, not by GitHub:
+installations from other organizations remain possible,
+they simply won't do anything.
+
 ***
 
 Hosting generously provided by <a href="https://www.unlockopen.com/home">UnlockOpen</a>.

--- a/index.js
+++ b/index.js
@@ -8,15 +8,17 @@ if (process.env.NODE_ENV === "dev") {
 const createApp = require("./lib/app"),
     Controller = require("./lib/controller"),
     { logger } = require("./lib/logger"),
-    { parseStartupQueue, processStartupQueue } = require("./lib/startup-queue");
+    { parseStartupQueue, processStartupQueue } = require("./lib/startup-queue"),
+    { parseAllowedOrgs } = require("./lib/allowed-orgs");
 
 var config = {
     githubSecret: process.env.GITHUB_SECRET,
     port: process.env.PORT || 5000,
-    nodeEnv: process.env.NODE_ENV
+    nodeEnv: process.env.NODE_ENV,
+    allowedOrgs: parseAllowedOrgs(process.env.ALLOWED_ORGS)
 };
 
-const controller = new Controller({ logger });
+const controller = new Controller({ logger, allowedOrgs: config.allowedOrgs });
 
 const queue = parseStartupQueue(process.env.STARTUP_QUEUE, logger);
 if (queue) {

--- a/lib/allowed-orgs.js
+++ b/lib/allowed-orgs.js
@@ -1,0 +1,37 @@
+"use strict";
+
+// The app can be restricted to a set of GitHub organizations (or user
+// accounts) through the ALLOWED_ORGS env variable, which holds a comma or
+// whitespace separated list of logins. When the list is empty or missing,
+// the app runs for every installation, as it always has.
+function parseAllowedOrgs(value) {
+    if (!value) return null;
+    // GitHub logins are case-insensitive, so normalize once, here.
+    let orgs = String(value).split(/[\s,]+/)
+        .filter(org => org.length > 0)
+        .map(org => org.toLowerCase());
+    return orgs.length > 0 ? orgs : null;
+}
+
+function isOrgAllowed(owner, allowedOrgs) {
+    if (!allowedOrgs) return true;
+    if (!owner) return false;
+    return allowedOrgs.includes(String(owner).toLowerCase());
+}
+
+// Pull request and job ids are of the form "owner/repo/number".
+function ownerFromId(id) {
+    if (typeof id != "string") return null;
+    let owner = id.split("/")[0];
+    return owner.length > 0 ? owner : null;
+}
+
+function orgNotAllowedError(owner) {
+    let error = new Error(`PR Preview is not enabled for ${ owner || "this organization" }`);
+    error.name = "ForbiddenOrgError";
+    error.orgNotAllowed = true;
+    error.status = 403;
+    return error;
+}
+
+module.exports = { parseAllowedOrgs, isOrgAllowed, ownerFromId, orgNotAllowedError };

--- a/lib/app.js
+++ b/lib/app.js
@@ -78,7 +78,7 @@ module.exports = function createApp(controller, config, log) {
             }
             res.redirect(url);
         } catch (err) {
-            res.status(400).send({ error: err.message });
+            res.status(err.status || 400).send({ error: err.message });
             log.error({ err, url: req.originalUrl }, `${req.originalUrl}: request failed`);
         } finally {
             next();

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -8,11 +8,14 @@ const { logger, jobLogger, logResult } = require("./logger");
 const github = require("simple-github");
 const { dismiss, dismissalReason } = require("./utils/error-utils");
 const prUrl = require("./utils/pr-url");
+const { isOrgAllowed, ownerFromId, orgNotAllowedError } = require("./allowed-orgs");
 
 class Controller {
     constructor(options) {
         options = options || {};
         this.log = options.logger || logger;
+        // `null` means the app isn't restricted to any organization.
+        this.allowedOrgs = options.allowedOrgs || null;
         this.currently_running = new Set();
         this.previewer_cache = new Map();
         this.renderer = new ViewBody();
@@ -45,6 +48,9 @@ class Controller {
         let repo = params.repo.trim();
         if (!regex.test(owner) || !regex.test(repo)) {
             throw new TypeError("Invalid repo or owner name");
+        }
+        if (!isOrgAllowed(owner, this.allowedOrgs)) {
+            throw orgNotAllowedError(owner);
         }
         let config = JSON.parse(params.config);
         Config.validate(config);
@@ -108,6 +114,14 @@ class Controller {
     queueJob(job) {
         // Startup-queue jobs come with an id only; every job gets a URL for the log.
         job.url = job.url || prUrl(job.id);
+
+        if (!isOrgAllowed(ownerFromId(job.id), this.allowedOrgs)) {
+            return {
+                job,
+                queued: false,
+                skipReason: 'organization not allowed'
+            };
+        }
 
         // Check if job is already in queue or currently running
         const isDuplicateInQueue = this.queue.some(queuedJob => queuedJob.id === job.id);

--- a/test/allowed-orgs.js
+++ b/test/allowed-orgs.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const assert = require('assert');
+const { parseAllowedOrgs, isOrgAllowed, ownerFromId } = require('../lib/allowed-orgs');
+
+suite('allowed-orgs', () => {
+    suite('parseAllowedOrgs', () => {
+        test('should return null when no list is set', () => {
+            assert.strictEqual(parseAllowedOrgs(undefined), null);
+            assert.strictEqual(parseAllowedOrgs(""), null);
+            assert.strictEqual(parseAllowedOrgs("  , "), null);
+        });
+
+        test('should parse comma and whitespace separated lists', () => {
+            assert.deepStrictEqual(parseAllowedOrgs("org1"), ["org1"]);
+            assert.deepStrictEqual(parseAllowedOrgs("org1,org2"), ["org1", "org2"]);
+            assert.deepStrictEqual(parseAllowedOrgs(" org1 , org2 "), ["org1", "org2"]);
+            assert.deepStrictEqual(parseAllowedOrgs("org1 org2"), ["org1", "org2"]);
+        });
+
+        test('should lowercase logins', () => {
+            assert.deepStrictEqual(parseAllowedOrgs("Org1,ORG2"), ["org1", "org2"]);
+        });
+    });
+
+    suite('isOrgAllowed', () => {
+        test('should allow everything when unrestricted', () => {
+            assert.strictEqual(isOrgAllowed("anyone", null), true);
+        });
+
+        test('should match logins case-insensitively', () => {
+            assert.strictEqual(isOrgAllowed("ORG1", ["org1"]), true);
+            assert.strictEqual(isOrgAllowed("org1", ["org1"]), true);
+        });
+
+        test('should reject logins which are not on the list', () => {
+            assert.strictEqual(isOrgAllowed("unauthorized-org1", ["org1", "org2"]), false);
+        });
+
+        test('should reject missing logins when restricted', () => {
+            assert.strictEqual(isOrgAllowed(undefined, ["org1"]), false);
+            assert.strictEqual(isOrgAllowed("", ["org1"]), false);
+        });
+    });
+
+    suite('ownerFromId', () => {
+        test('should extract the owner from a job id', () => {
+            assert.strictEqual(ownerFromId("org1/repo/123"), "org1");
+        });
+
+        test('should return null for unusable ids', () => {
+            assert.strictEqual(ownerFromId(undefined), null);
+            assert.strictEqual(ownerFromId("/repo/123"), null);
+        });
+    });
+});

--- a/test/server.js
+++ b/test/server.js
@@ -127,6 +127,83 @@ suite('Server', () => {
                 done(err);
             });
     });
+
+    test('should ignore pull requests from organizations which are not allowed', (done) => {
+        const controller = new Controller({ allowedOrgs: ['org1'] });
+        const config = { githubSecret: 'test-secret', nodeEnv: 'development' };
+        const app = createApp(controller, config);
+
+        request(app)
+            .post('/github-hook')
+            .send({
+                action: 'opened',
+                number: 123,
+                installation: { id: 'test-installation' },
+                pull_request: {
+                    base: {
+                        repo: {
+                            full_name: 'unauthorized-org1/repo'
+                        }
+                    }
+                },
+                sender: {
+                    login: 'testuser'
+                }
+            })
+            .expect(200)
+            .end((err) => {
+                assert.strictEqual(controller.queue.length, 0, 'Job should not have been queued');
+                done(err);
+            });
+    });
+
+    test('should process pull requests from allowed organizations', (done) => {
+        const controller = new Controller({ allowedOrgs: ['org1'] });
+        const config = { githubSecret: 'test-secret', nodeEnv: 'development' };
+        const app = createApp(controller, config);
+
+        // Prevent the queue from being processed so we can inspect it.
+        controller.processQueue = () => {};
+
+        request(app)
+            .post('/github-hook')
+            .send({
+                action: 'opened',
+                number: 123,
+                installation: { id: 'test-installation' },
+                pull_request: {
+                    base: {
+                        repo: {
+                            full_name: 'ORG1/repo'
+                        }
+                    }
+                },
+                sender: {
+                    login: 'testuser'
+                }
+            })
+            .expect(200)
+            .end((err) => {
+                assert.strictEqual(controller.queue.length, 1, 'Job should have been queued');
+                done(err);
+            });
+    });
+
+    test('should reject config requests for organizations which are not allowed', (done) => {
+        const controller = new Controller({ allowedOrgs: ['org1'] });
+        const config = { githubSecret: 'test-secret', nodeEnv: 'development' };
+        const app = createApp(controller, config);
+
+        request(app)
+            .post('/config')
+            .type('form')
+            .send({ owner: 'unauthorized-org1', repo: 'repo', config: '{}', validate: '1' })
+            .expect(403)
+            .expect(res => {
+                assert.match(res.body.error, /not enabled for unauthorized-org1/);
+            })
+            .end(done);
+    });
 });
 
 suite('Server signature verification', () => {
@@ -237,6 +314,17 @@ suite('Server webhook logging', () => {
         controller.currently_running.add('test/repo/123');
         request(app).post('/github-hook').send(prPayload('synchronize')).expect(200).end(err => {
             assert.deepEqual(lines(), [['https://github.com/test/repo/pull/123', 'synchronize', 'skipped', 'already processing', 'skipped (already processing)']]);
+            done(err);
+        });
+    });
+
+    test('says why a pull_request event from a disallowed org was skipped', (done) => {
+        const log = memoryLogger();
+        const controller = new Controller({ logger: log, allowedOrgs: ['org1'] });
+        const app = createApp(controller, { githubSecret: 'x', nodeEnv: 'development' }, log);
+        request(app).post('/github-hook').send(prPayload('synchronize')).expect(200).end(err => {
+            const lines = log.records().map(r => [r.pr, r.action, r.status, r.reason, r.msg]);
+            assert.deepEqual(lines, [['https://github.com/test/repo/pull/123', 'synchronize', 'skipped', 'organization not allowed', 'skipped (organization not allowed)']]);
             done(err);
         });
     });


### PR DESCRIPTION
Lets a self-hosted instance restrict itself to a set of GitHub organizations (or user accounts) via a new `ALLOWED_ORGS` environment variable. Unset, nothing changes: the app runs for every installation, as before.