### PR TITLE
Add a GET /health route for the Clever Cloud deployment check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ See `DEPLOYMENT.md` at the repo root for the full list of environment variables/
 **Entry Point (`index.js`)**
 - Express server handling GitHub webhooks at `/github-hook`
 - Configuration endpoint at `/config` for testing configs
+- Health check at `GET /health` (returns the queue state; Clever Cloud validates deploys against it)
 - Startup queue processing for batch operations
 - Main webhook handler processes PR events: opened, edited, reopened, synchronize
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -109,6 +109,7 @@ The Node.js runtime needs almost nothing from us:
 - **Start command** — the runtime runs `scripts.start` from `package.json`, which is `node index.js`. No `CC_RUN_COMMAND` needed.
 - **Dependencies** — installed at build time from `package.json`. Dev dependencies (`mocha`, `supertest`) are *not* installed by default, which is what we want; leave `CC_NODE_DEV_DEPENDENCIES` unset.
 - **Build step** — there is none (no `build` script), so nothing runs between install and start.
+- **Health check** — set `CC_HEALTH_CHECK_PATH` to `/health`. Without it the platform only checks that something is listening on port 8080, which a process can do and still be broken; with it the orchestrator requests `GET /health` after start-up and only counts the deploy as successful on a 2xx. The route answers `{"status":"ok"}` with the uptime and the queue depth, and probes nothing else: every build runs on a remote service, so there is no local dependency whose absence should fail a deploy.
 - **Node version** — set `CC_NODE_VERSION` to `22` alongside the other environment variables. The `engines` range in `package.json` carries the upper bound (see [Requirements](#requirements)), but pin this too rather than relying on the platform to honour it: with an open-ended range the platform resolves to the newest Node available, which is how a deployment ends up on a version the app cannot run on.
 
   **Changing it takes a rebuild, not a plain restart.** The Node version is baked in at build time, so a restart re-injects the variable into an image still carrying the old Node — the logs report the old version and the change looks like it did not apply. Use *rebuild and restart* from the application header, and confirm the expected `Node.js v22.x` in the Logs panel.
@@ -171,7 +172,9 @@ How a deploy is triggered depends on the choice made at creation: a push to the 
 - **Logs** streams build and application output. A successful boot logs `Express server listening on port 8080 in production mode`.
 - The application header carries **restart** controls — a plain restart, and a rebuild-and-restart that redoes the build from the current commit. Use the plain restart after an environment-variable change.
 
-If a deploy is marked unhealthy even though the app logged that it is listening, check the health-check configuration: this app exposes no `GET` route at all — only `POST /github-hook` and `POST /config` — so an HTTP health check against `/` will not get a 2xx.
+If a deploy is marked unhealthy even though the app logged that it is listening, check the health-check configuration: `CC_HEALTH_CHECK_PATH` must be `/health`. `GET /health` is the only `GET` route the app exposes — the others are `POST /github-hook` and `POST /config` — so a check against `/` or any other path gets a 404 and fails the deploy.
+
+The same route is a quick way to see whether the running instance is busy before restarting it: `curl https://<host>/health` reports how many jobs are queued and running.
 
 The [`clever-tools` CLI](https://github.com/CleverCloud/clever-tools) offers the same operations from a terminal (`clever logs`, `clever restart`, `clever env`) if that is ever preferable for day-to-day work. It is not needed for any step in this document.
 
@@ -213,6 +216,7 @@ Used when the PR owner is `whatwg`. Set `ALLOW_MULTIPLE_AWS_BUCKETS=no` to skip 
 ### Clever Cloud platform variables
 
 - `CC_NODE_VERSION` — Node.js version to run (pin to `22`; must be below 24 — see [Requirements](#requirements))
+- `CC_HEALTH_CHECK_PATH` — set to `/health`; the orchestrator requests it after start-up and fails the deploy unless it gets a 2xx (see [Build and start](#build-and-start))
 - `CC_NODE_DEV_DEPENDENCIES` — leave unset; dev dependencies are not installed by default
 - `CC_RUN_COMMAND` — not needed; the runtime uses `npm start`
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -67,6 +67,21 @@ module.exports = function createApp(controller, config, log) {
         next();
     });
 
+    // Deployment health check. Clever Cloud calls the path named in
+    // CC_HEALTH_CHECK_PATH once the process is up and treats a 2xx as a
+    // validated deploy; anything else fails it. Every build happens on
+    // remote services, so there is no local dependency to probe: a process
+    // that answers at all is a healthy one. The queue counts are for a
+    // human reading the response, not for the check.
+    app.get('/health', function (req, res) {
+        res.json({
+            status:  "ok",
+            uptime:  Math.round(process.uptime()),
+            queued:  controller.queue.length,
+            running: controller.currently_running.size
+        });
+    });
+
     app.post('/config', bodyParser.urlencoded({ extended: false }), async function (req, res, next) {
         try {
             let params = req.body;

--- a/test/server.js
+++ b/test/server.js
@@ -77,6 +77,28 @@ suite('Server', () => {
             .end(done);
     });
 
+    test('should answer the health check with a 2xx and the queue state', (done) => {
+        const controller = new Controller();
+        const config = { githubSecret: 'test-secret', nodeEnv: 'production' };
+        const app = createApp(controller, config);
+
+        controller.queue.push({ id: 'test/repo/1' });
+        controller.currently_running.add('test/repo/2');
+
+        request(app)
+            .get('/health')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .end((err, res) => {
+                if (err) return done(err);
+                assert.strictEqual(res.body.status, 'ok');
+                assert.strictEqual(typeof res.body.uptime, 'number');
+                assert.strictEqual(res.body.queued, 1);
+                assert.strictEqual(res.body.running, 1);
+                done();
+            });
+    });
+
     test('should create app successfully with valid config', () => {
         const controller = new Controller();
         const config = { githubSecret: 'test-secret' };


### PR DESCRIPTION
Clever Cloud only validates a deploy by checking that something listens
on port 8080 unless CC_HEALTH_CHECK_PATH names a path it can request,
and this app had no GET route at all, so there was nothing to point it
at and DEPLOYMENT.md could only warn that a check against / would fail.

Add GET /health, answering 200 with {"status":"ok"}, the uptime and the
number of queued and running jobs. It probes nothing else: every build
happens on a remote service, so there is no local dependency whose
absence should fail a deploy, and a process that answers is a healthy
one. The counts are there for a human deciding whether it is safe to
restart.

DEPLOYMENT.md now says to set CC_HEALTH_CHECK_PATH=/health and what the
route does; CONTRIBUTING.md lists the endpoint.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GvjKNAqHb5GKpA2kwrjYAh